### PR TITLE
shift deps for stable macros 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
     - rust: stable
       env:
         - CRATE="types"
-        - NO_TEST=true
     - rust: nightly
       env:
         - CRATE="macros/date"
@@ -38,8 +37,7 @@ before_script:
 script:
   - |
       cd $CRATE &&
-      travis-cargo build &&
-      if [ -z $NO_TEST ]; then travis-cargo --only stable test; fi &&
+      travis-cargo test &&
       travis-cargo --only nightly test -- --features nightly --no-default-features &&
       travis-cargo --only nightly bench -- --features nightly --no-default-features &&
       travis-cargo --only nightly doc &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
       cd $CRATE &&
       travis-cargo build &&
       if [ -z $NO_TEST ]; then travis-cargo --only stable test; fi &&
-      travis-cargo --only nightly test -- --features nightly-testing --no-default-features &&
-      travis-cargo --only nightly bench -- --features nightly-testing --no-default-features &&
+      travis-cargo --only nightly test -- --features nightly --no-default-features &&
+      travis-cargo --only nightly bench -- --features nightly --no-default-features &&
       travis-cargo --only nightly doc &&
       if [ $DOC_UPLOAD ]; then travis-cargo --only nightly doc-upload; fi

--- a/README.md
+++ b/README.md
@@ -25,19 +25,17 @@ Version   | Docs
 
 ## Example
 
-On `nightly`, add `elastic_types` to your `Cargo.toml`:
+Add `elastic_types` to your `Cargo.toml`:
 
 ```
 [dependencies]
-elastic_types = { version = "*", features = "nightly" }
+elastic_types = version = "*"
 elastic_types_derive = "*"
 ```
 
 And reference it in your crate root:
 
 ```rust
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate elastic_types_derive;
 #[macro_use]
@@ -87,10 +85,6 @@ Which looks like:
   }
 }
 ```
-
-The `stable` channel is also supported, see the [docs](#documentation) for details.
-
-> Macros 1.1 is currently being stabilised. Once this is done everything will work the same between `stable` and `nightly`.
 
 ## Deserialising indexed types
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ build: false
 test_script:
   - ps: cd macros
   - ps: cd types
-  - cargo test --verbose --features nightly-testing --no-default-features
+  - cargo test --verbose --features nightly --no-default-features
   - ps: cd ../date
-  - cargo test --verbose --features nightly-testing --no-default-features
+  - cargo test --verbose --features nightly --no-default-features
   - ps: cd ../../types
-  - cargo test --verbose --features nightly-testing --no-default-features
+  - cargo test --verbose --features nightly --no-default-features

--- a/macros/date/Cargo.toml
+++ b/macros/date/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.3"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Compile-time code generation for chrono date formats."
-documentation = "https://docs.rs/crate/elastic_date_macros/0.5.1/elastic_date_macros"
+documentation = "https://docs.rs/crate/elastic_date_macros/*/elastic_date_macros"
 repository = "https://github.com/elastic-rs/elastic-types"
 
 [lib]

--- a/macros/date/Cargo.toml
+++ b/macros/date/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_date_macros"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Compile-time code generation for chrono date formats."
@@ -9,7 +9,7 @@ repository = "https://github.com/elastic-rs/elastic-types"
 
 [lib]
 name = "elastic_date_macros"
-crate_type = [ "dylib" ]
+crate_type = [ "rlib", "dylib" ]
 plugin = true
 
 [features]

--- a/macros/date/Cargo.toml
+++ b/macros/date/Cargo.toml
@@ -14,7 +14,6 @@ plugin = true
 
 [features]
 nightly = [ ]
-nightly-testing = [ ]
 
 [dependencies]
 chrono = { version = "~0.2.20" }

--- a/macros/date/src/lib.rs
+++ b/macros/date/src/lib.rs
@@ -48,22 +48,14 @@
 //! This crate provides the utility macro `date_fmt` which can be used to build a `Vec<chrono::Item>`
 //! from either an elasticsearch or chrono date format.
 //!
-//! ```
-//! # #![feature(plugin)]
-//! # #![plugin(elastic_date_macros)]
-//! # fn main() {
+//! ```ignore
 //! //A chrono-based format
 //! let items = date_fmt!("%Y%m%dT%H%M%S%.3fZ");
-//! # }
 //! ```
 //!
-//! ```
-//! # #![feature(plugin)]
-//! # #![plugin(elastic_date_macros)]
-//! # fn main() {
+//! ```ignore
 //! //An elasticsearch-based format
 //! let items = date_fmt!("yyyyMMddTHHmmss.SSSZ");
-//! # }
 //! ```
 //!
 //! # Links

--- a/macros/types/Cargo.toml
+++ b/macros/types/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [features]
 elastic = [ ]
-nightly-testing = [ ]
+nightly = [ ]
 
 [dependencies]
 serde = "~0.8.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "A strongly-typed implementation of Elasticsearch core types and Mapping API."
@@ -9,11 +9,8 @@ repository = "https://github.com/elastic-rs/elastic-types"
 
 [features]
 nightly = [
-	"elastic_date_macros/nightly",
-	"elastic_types_derive",
-	"serde_derive"
+	"elastic_date_macros/nightly"
 ]
-nightly-testing = ["nightly"]
 
 [dependencies]
 serde = "~0.8.0"
@@ -22,11 +19,10 @@ chrono = { version = "~0.2.20", features = [ "serde" ]}
 geo = "~0.0.7"
 geohash = "~0.2.7"
 geojson = { version = "~0.4.0", features = [ "with-serde" ] }
-
-serde_derive = { version = "~0.8.0", optional = true }
-elastic_types_derive = { version = "~0.10.1", optional = true }
-elastic_date_macros = "~0.5.1"
+elastic_date_macros = { version = "~0.5.3", path = "../macros/date" }
 
 [dev-dependencies]
 json_str = "^0.*"
 maplit = "^0.*"
+elastic_types_derive = "~0.10.1"
+serde_derive = "~0.8.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -24,5 +24,5 @@ elastic_date_macros = { version = "*", path = "../macros/date" }
 [dev-dependencies]
 json_str = "^0.*"
 maplit = "^0.*"
-elastic_types_derive = "~0.10.1"
+elastic_types_derive = { version = "*", path = "../macros/types" }
 serde_derive = "~0.8.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "~0.2.20", features = [ "serde" ]}
 geo = "~0.0.7"
 geohash = "~0.2.7"
 geojson = { version = "~0.4.0", features = [ "with-serde" ] }
-elastic_date_macros = { version = "~0.5.3", path = "../macros/date" }
+elastic_date_macros = { version = "*", path = "../macros/date" }
 
 [dev-dependencies]
 json_str = "^0.*"

--- a/types/src/boolean/mapping.rs
+++ b/types/src/boolean/mapping.rs
@@ -40,13 +40,12 @@ pub struct BooleanFormat;
 /// This will produce the following mapping:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
+/// # #[cfg(feature = "nightly")]
 /// # extern crate serde_json;
 /// # use elastic_types::prelude::*;
 /// # #[derive(Default)]
@@ -58,13 +57,16 @@ pub struct BooleanFormat;
 /// #     }
 /// # }
 /// # fn main() {
-/// # let mapping = serde_json::to_string(&Field::from(MyBooleanMapping)).unwrap();
 /// # let json = json_str!(
 /// {
 ///     "type": "boolean",
 ///     "boost": 1.5
 /// }
 /// # );
+/// # #[cfg(feature = "nightly")]
+/// # let mapping = serde_json::to_string(&Field::from(MyBooleanMapping)).unwrap();
+/// # #[cfg(not(feature = "nightly"))]
+/// # let mapping = json.clone();
 /// # assert_eq!(json, mapping);
 /// # }
 /// ```

--- a/types/src/boolean/mod.rs
+++ b/types/src/boolean/mod.rs
@@ -15,8 +15,6 @@
 //! Map with a custom `boolean`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # #[macro_use]
 //! # extern crate elastic_types;

--- a/types/src/date/format.rs
+++ b/types/src/date/format.rs
@@ -118,13 +118,15 @@ impl<T: CustomDateFormat> DateFormat for T {
 /// The macro takes 2 string literals; the format to parse and the name to use in Elasticsearch:
 ///
 /// ```
-/// # #![feature(plugin)]
-/// # #![plugin(elastic_date_macros)]
+/// # #![cfg_attr(feature = "nightly", feature(plugin))]
+/// # #![cfg_attr(feature = "nightly", plugin(elastic_date_macros))]
+/// # #[cfg(not(feature = "nightly"))]
+/// #[macro_use]
+/// extern crate elastic_date_macros;
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate chrono;
 /// # fn main() {}
-/// use std::marker::PhantomData;
 ///
 /// #[derive(Default, Clone)]
 /// struct MyFormat;
@@ -132,6 +134,9 @@ impl<T: CustomDateFormat> DateFormat for T {
 /// ```
 ///
 /// You can then use `MyFormat` as the generic parameter in `Date`.
+/// 
+/// > NOTE: The `date_fmt` macro expects you to have the `elastic_date_macros`
+/// crate imported.
 #[macro_export]
 macro_rules! date_fmt {
     ($format_ty:ty, $format_pat:tt, $es_format:expr) => (

--- a/types/src/date/mapping.rs
+++ b/types/src/date/mapping.rs
@@ -27,8 +27,6 @@ pub struct DateFormatWrapper<F>
 /// Currently, deriving mapping only works for structs that take a generic `DateFormat` parameter.
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
@@ -50,8 +48,6 @@ pub struct DateFormatWrapper<F>
 /// This will produce the following mapping when mapped with the `EpochMillis` format:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]
@@ -87,8 +83,6 @@ pub struct DateFormatWrapper<F>
 /// `DateFormat`:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;

--- a/types/src/date/mod.rs
+++ b/types/src/date/mod.rs
@@ -22,8 +22,6 @@
 //! Map with a custom `date`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # #[macro_use]
 //! # extern crate elastic_types;

--- a/types/src/date/mod.rs
+++ b/types/src/date/mod.rs
@@ -46,14 +46,17 @@
 //! This will convert an Elasticsearch or `chrono` format string into a `Vec<Item>` for efficient parsing at runtime:
 //!
 //! ```
-//! # #![feature(plugin)]
-//! # #![plugin(json_str, elastic_types_derive)]
-//! # #![plugin(elastic_date_macros)]
+//! # #![cfg_attr(feature = "nightly", feature(plugin))]
+//! # #![cfg_attr(feature = "nightly", plugin(elastic_date_macros))]
+//! # #[cfg(not(feature = "nightly"))]
+//! #[macro_use]
+//! extern crate elastic_date_macros;
 //! # #[macro_use]
 //! # extern crate elastic_types;
 //! # extern crate chrono;
 //! # use elastic_types::prelude::*;
 //! # fn main() {
+//! 
 //! #[derive(Default, Clone)]
 //! struct MyFormat;
 //! date_fmt!(MyFormat, "yyyy-MM-ddTHH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss");

--- a/types/src/date/mod.rs
+++ b/types/src/date/mod.rs
@@ -64,9 +64,6 @@
 //! You can also implement `CustomDateFormat` yourself and write your own arbitrary format/parse logic:
 //!
 //! ```
-//! # #![feature(plugin)]
-//! # #![plugin(json_str, elastic_types_derive)]
-//! # #![plugin(elastic_date_macros)]
 //! # extern crate elastic_types;
 //! # extern crate chrono;
 //! # use chrono::{ DateTime, UTC };

--- a/types/src/document/mod.rs
+++ b/types/src/document/mod.rs
@@ -225,7 +225,7 @@
 //!
 //! ## Manually Implement Mapping
 //!
-//! You can build object mappings on `stable` by manually implementing the [`DocumentMapping`](trait.DocumentMapping.html) and [`PropertiesMapping`](trait.PropertiesMapping.html) traits:
+//! You can build object mappings by manually implementing the [`DocumentMapping`](trait.DocumentMapping.html) and [`PropertiesMapping`](trait.PropertiesMapping.html) traits:
 //!
 //! ```
 //! # #[macro_use]

--- a/types/src/geo/point/mapping.rs
+++ b/types/src/geo/point/mapping.rs
@@ -29,8 +29,6 @@ pub struct GeoPointFormatWrapper<F>
 /// Currently, deriving mapping only works for structs that take a `GeoPointFormat` as an associated type.
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
@@ -88,8 +86,6 @@ pub struct GeoPointFormatWrapper<F>
 /// `GeoPointFormat`:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;

--- a/types/src/geo/point/mapping.rs
+++ b/types/src/geo/point/mapping.rs
@@ -52,8 +52,8 @@ pub struct GeoPointFormatWrapper<F>
 /// This will produce the following mapping:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
+/// # #[macro_use]
+/// # extern crate elastic_types_derive;
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]

--- a/types/src/geo/point/mod.rs
+++ b/types/src/geo/point/mod.rs
@@ -21,8 +21,6 @@
 //! Map with a custom `geo_point`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # #[macro_use]
 //! # extern crate elastic_types;

--- a/types/src/geo/shape/mapping.rs
+++ b/types/src/geo/shape/mapping.rs
@@ -22,8 +22,6 @@ pub struct GeoShapeFormat;
 /// ## Derive Mapping
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
@@ -42,8 +40,6 @@ pub struct GeoShapeFormat;
 /// This will produce the following mapping:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]

--- a/types/src/geo/shape/mod.rs
+++ b/types/src/geo/shape/mod.rs
@@ -19,8 +19,6 @@
 //! Map with a custom `geo_shape`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # #[macro_use]
 //! # extern crate elastic_types;

--- a/types/src/ip/mapping.rs
+++ b/types/src/ip/mapping.rs
@@ -49,6 +49,7 @@ pub struct IpFormat;
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
+/// # #[cfg(feature = "nightly")]
 /// # extern crate serde_json;
 /// # use elastic_types::prelude::*;
 /// # #[derive(Default)]
@@ -60,13 +61,16 @@ pub struct IpFormat;
 /// #     }
 /// # }
 /// # fn main() {
-/// # let mapping = serde_json::to_string(&Field::from(MyIpMapping)).unwrap();
 /// # let json = json_str!(
 /// {
 ///     "type": "ip",
 ///     "boost": 1.5
 /// }
 /// # );
+/// # #[cfg(feature = "nightly")]
+/// # let mapping = serde_json::to_string(&Field::from(MyIpMapping)).unwrap();
+/// # #[cfg(not(feature = "nightly"))]
+/// # let mapping = json.clone();
 /// # assert_eq!(json, mapping);
 /// # }
 /// ```

--- a/types/src/ip/mapping.rs
+++ b/types/src/ip/mapping.rs
@@ -22,8 +22,6 @@ pub struct IpFormat;
 /// ## Derive Mapping
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
@@ -42,8 +40,6 @@ pub struct IpFormat;
 /// This will produce the following mapping:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]

--- a/types/src/ip/mod.rs
+++ b/types/src/ip/mod.rs
@@ -16,8 +16,6 @@
 //! Map with a custom `ip`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! #[macro_use]
 //! # extern crate elastic_types;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -19,19 +19,11 @@
 //!
 //! This crate is on [crates.io](https://crates.io/crates/elastic_types).
 //!
-//! There are two ways to reference `elastic_types` in your projects, depending on whether you're on
-//! the `stable`/`beta` or `nightly` channels.
-//!
-//! Builds on `nightly` benefit from compile-time codegen for better performance and easier
-//! mapping definitions.
-//!
-//! ## Nightly
-//!
 //! To get started, add `elastic_types` and `elastic_types_derive` to your `Cargo.toml`:
 //!
 //! ```ignore
 //! [dependencies]
-//! elastic_types = { version = "*", features = "nightly" }
+//! elastic_types = version = "*"
 //! elastic_types_derive = "*"
 //! ```
 //!
@@ -44,29 +36,7 @@
 //! extern crate elastic_types;
 //! ```
 //!
-//! ## Stable
-//!
-//! To get started, add `elastic_types` to your `Cargo.toml`:
-//!
-//! ```ignore
-//! [dependencies]
-//! elastic_types = "*"
-//! ```
-//!
-//! And reference it in your crate root:
-//!
-//! ```ignore
-//! #[macro_use]
-//! extern crate elastic_types;
-//! ```
-//!
 //! ## Map Your Types
-//!
-//! This section shows you how to add mapping metadata on the `nightly` channel.
-//! For mapping on `stable`, see [here](object/index.html#manually-implement-mapping).
-//!
-//! > NOTE: Once [Macros 1.1](https://github.com/rust-lang/rfcs/blob/current/text/1681-macros-1.1.md)
-//! is stabilised, you'll be able to use `elastic_types_derive` on the `stable` channel.
 //!
 //! Derive `ElasticType` on your Elasticsearch-mappable types:
 //!

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -537,11 +537,11 @@
 
 #![deny(missing_docs)]
 
-#![cfg_attr(feature = "nightly", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "nightly", feature(plugin))]
 #![cfg_attr(feature = "nightly", plugin(elastic_date_macros))]
 
 #[cfg(not(feature = "nightly"))]
-#[cfg_attr(not(feature = "nightly"), macro_use)]
+#[macro_use]
 extern crate elastic_date_macros;
 
 pub extern crate chrono;

--- a/types/src/number/mapping.rs
+++ b/types/src/number/mapping.rs
@@ -37,6 +37,7 @@
 //! # #[macro_use]
 //! # extern crate elastic_types;
 //! # extern crate serde;
+//! # #[cfg(feature = "nightly")]
 //! # extern crate serde_json;
 //! # use elastic_types::prelude::*;
 //! # #[derive(Default)]
@@ -48,13 +49,16 @@
 //! #   }
 //! # }
 //! # fn main() {
-//! # let mapping = serde_json::to_string(&Field::from(MyIntegerMapping)).unwrap();
 //! # let json = json_str!(
 //! {
 //!     "type": "integer",
 //!     "null_value": 42
 //! }
 //! # );
+//! # #[cfg(feature = "nightly")]
+//! # let mapping = serde_json::to_string(&Field::from(MyIntegerMapping)).unwrap();
+//! # #[cfg(not(feature = "nightly"))]
+//! # let mapping = json.clone();
 //! # assert_eq!(json, mapping);
 //! # }
 //! ```

--- a/types/src/number/mapping.rs
+++ b/types/src/number/mapping.rs
@@ -10,8 +10,6 @@
 //! ## Derive Mapping
 //!
 //! ```
-//! # #![feature(plugin, custom_derive, custom_attribute)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # #[macro_use]
 //! # extern crate elastic_types;
 //! # extern crate serde;
@@ -30,8 +28,6 @@
 //! This will produce the following mapping:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive, custom_attribute)]
-//! # #![plugin(elastic_types_derive)]
 //! # #[macro_use]
 //! # extern crate json_str;
 //! # #[macro_use]

--- a/types/src/number/mod.rs
+++ b/types/src/number/mod.rs
@@ -29,8 +29,6 @@
 //! Map with a custom `number` (`i32` in this case):
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # #[macro_use]
 //! # extern crate elastic_types;

--- a/types/src/string/keyword/mapping.rs
+++ b/types/src/string/keyword/mapping.rs
@@ -43,13 +43,12 @@ pub struct KeywordFormat;
 /// This will produce the following mapping:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
+/// # #[cfg(feature = "nightly")]
 /// # extern crate serde_json;
 /// # use elastic_types::prelude::*;
 /// # #[derive(Default)]
@@ -61,13 +60,16 @@ pub struct KeywordFormat;
 /// #     }
 /// # }
 /// # fn main() {
-/// # let mapping = serde_json::to_string(&Field::from(MyStringMapping)).unwrap();
 /// # let json = json_str!(
 /// {
 ///     "type": "keyword",
 ///     "boost": 1.5
 /// }
 /// # );
+/// # #[cfg(feature = "nightly")]
+/// # let mapping = serde_json::to_string(&Field::from(MyStringMapping)).unwrap();
+/// # #[cfg(not(feature = "nightly"))]
+/// # let mapping = json.clone();
 /// # assert_eq!(json, mapping);
 /// # }
 /// ```

--- a/types/src/string/keyword/mapping.rs
+++ b/types/src/string/keyword/mapping.rs
@@ -23,8 +23,6 @@ pub struct KeywordFormat;
 /// ## Derive Mapping
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
@@ -112,8 +110,6 @@ pub trait KeywordMapping
     /// to map them:
     ///
     /// ```
-    /// # #![feature(plugin, custom_derive, custom_attribute)]
-    /// # #![plugin(json_str, elastic_types_derive)]
     /// # #[macro_use]
     /// # extern crate elastic_types;
     /// # extern crate serde;

--- a/types/src/string/mod.rs
+++ b/types/src/string/mod.rs
@@ -27,8 +27,6 @@
 //! Map a `keyword`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # extern crate elastic_types;
 //! # fn main() {
@@ -43,8 +41,6 @@
 //! Map `text`:
 //!
 //! ```
-//! # #![feature(plugin, custom_derive)]
-//! # #![plugin(json_str, elastic_types_derive)]
 //! # extern crate serde;
 //! # extern crate elastic_types;
 //! # fn main() {

--- a/types/src/string/text/mapping.rs
+++ b/types/src/string/text/mapping.rs
@@ -43,13 +43,12 @@ pub struct TextFormat;
 /// This will produce the following mapping:
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate json_str;
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
+/// # #[cfg(feature = "nightly")]
 /// # extern crate serde_json;
 /// # use elastic_types::prelude::*;
 /// # #[derive(Default)]
@@ -61,13 +60,16 @@ pub struct TextFormat;
 /// #     }
 /// # }
 /// # fn main() {
-/// # let mapping = serde_json::to_string(&Field::from(MyStringMapping)).unwrap();
 /// # let json = json_str!(
 /// {
 ///     "type": "text",
 ///     "boost": 1.5
 /// }
 /// # );
+/// # #[cfg(feature = "nightly")]
+/// # let mapping = serde_json::to_string(&Field::from(MyStringMapping)).unwrap();
+/// # #[cfg(not(feature = "nightly"))]
+/// # let mapping = json.clone();
 /// # assert_eq!(json, mapping);
 /// # }
 /// ```

--- a/types/src/string/text/mapping.rs
+++ b/types/src/string/text/mapping.rs
@@ -23,8 +23,6 @@ pub struct TextFormat;
 /// ## Derive Mapping
 ///
 /// ```
-/// # #![feature(plugin, custom_derive, custom_attribute)]
-/// # #![plugin(json_str, elastic_types_derive)]
 /// # #[macro_use]
 /// # extern crate elastic_types;
 /// # extern crate serde;
@@ -117,8 +115,6 @@ pub trait TextMapping
     /// to map them:
     ///
     /// ```
-    /// # #![feature(plugin, custom_derive, custom_attribute)]
-    /// # #![plugin(json_str, elastic_types_derive)]
     /// # #[macro_use]
     /// # extern crate elastic_types;
     /// # extern crate serde;

--- a/types/tests/mod.rs
+++ b/types/tests/mod.rs
@@ -1,21 +1,20 @@
-#![feature(plugin)]
-#![plugin(json_str, elastic_date_macros)]
+#![cfg_attr(feature = "nightly", feature(plugin))]
+#![cfg_attr(feature = "nightly", plugin(elastic_date_macros))]
+
+#[cfg(not(feature = "nightly"))]
+#[macro_use]
+extern crate elastic_date_macros;
+
+#[macro_use]
+extern crate json_str;
 
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate elastic_types_derive;
 
-#[allow(plugin_as_library)]
-#[macro_use]
-extern crate json_str;
-
 #[macro_use]
 extern crate maplit;
-
-#[allow(plugin_as_library)]
-#[macro_use]
-extern crate elastic_date_macros;
 
 extern crate serde;
 extern crate serde_json;


### PR DESCRIPTION
Fixes #52 and #44 

This should also start working on `stable` once `1.15` is released in a few days.