### PR TITLE
Add a delayed date format

### DIFF
--- a/types-derive-internals/Cargo.toml
+++ b/types-derive-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types_derive_internals"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Codegen internals for elastic_types."

--- a/types-derive-internals/src/date_format/mod.rs
+++ b/types-derive-internals/src/date_format/mod.rs
@@ -57,7 +57,7 @@ fn impl_date_format(crate_root: Tokens,
     );
 
     let format_fn = quote!(
-        fn format(date: &::chrono::DateTime<::chrono::UTC>) -> String {
+        fn format<'a>(date: &::chrono::DateTime<::chrono::UTC>) -> #crate_root::date::FormattedDate<'a> {
             let fmt = vec![ #(#format),* ];
 
             #crate_root::date::format_with_tokens(date, fmt)

--- a/types-derive/Cargo.toml
+++ b/types-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types_derive"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Compile-time code generation for Elasticsearch type implementations."
@@ -11,6 +11,6 @@ name = "elastic_types_derive"
 proc-macro = true
 
 [dependencies]
-elastic_types_derive_internals = "~0.1.0"
+elastic_types_derive_internals = { version = "~0.2.0", path = "../types-derive-internals" }
 syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
 quote = "~0.3.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "A strongly-typed implementation of Elasticsearch core types and Mapping API."
@@ -8,14 +8,14 @@ documentation = "https://docs.rs/elastic_types/*/elastic_types/"
 repository = "https://github.com/elastic-rs/elastic-types"
 
 [dependencies]
-serde = "~0.9.0"
+serde = "~0.9.14"
 serde_json = "~0.9.0"
 chrono = { version = "~0.3.0", features = [ "serde" ]}
 geo = "~0.3.0"
 geohash = "~0.3.0"
 geojson = "~0.5.0"
 serde_derive = "~0.9.0"
-elastic_types_derive = "~0.13.0"
+elastic_types_derive = { version = "~0.14.0", path = "../types-derive" }
 
 [dev-dependencies]
 json_str = "^0.*"

--- a/types/benches/date/mod.rs
+++ b/types/benches/date/mod.rs
@@ -7,7 +7,7 @@ use test::Bencher;
 #[bench]
 fn parse_string(b: &mut Bencher) {
     b.iter(|| {
-        Date::<BasicDateTime>::parse("20150620T134501.034Z").unwrap()
+        serde_json::from_str::<Date<BasicDateTime>>("\"20150620T134501.034Z\"").unwrap()
     });
 }
 
@@ -16,14 +16,14 @@ fn fmt_string(b: &mut Bencher) {
     let dt: Date<DefaultDateFormat> = Date::now();
 
     b.iter(|| {
-        dt.format()
+        serde_json::to_string(&dt).unwrap()
     });
 }
 
 #[bench]
 fn parse_epoch(b: &mut Bencher) {
     b.iter(|| {
-        Date::<EpochMillis>::parse("1435935302478").unwrap()
+        serde_json::from_str::<Date<EpochMillis>>("\"1435935302478\"").unwrap()
     });
 }
 
@@ -32,7 +32,7 @@ fn fmt_epoch(b: &mut Bencher) {
     let dt = Date::<EpochMillis>::now();
 
     b.iter(|| {
-        dt.format()
+        serde_json::to_string(&dt).unwrap()
     });
 }
 

--- a/types/src/date/date.rs
+++ b/types/src/date/date.rs
@@ -173,7 +173,7 @@ impl<F, M> Date<F, M>
     /// println!("{}", fmt);
     /// ```
     pub fn format(&self) -> String {
-        F::format(&self.value).to_string()
+        F::format(&self.value).into()
     }
 
     /// Change the format/mapping of this date.
@@ -309,7 +309,7 @@ impl<'a, F, M> DateBrw<'a, F, M>
 
     #[doc(hidden)]
     pub fn format(&self) -> String {
-        F::format(&self.value).to_string()
+        F::format(&self.value).into()
     }
 }
 

--- a/types/src/date/date.rs
+++ b/types/src/date/date.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::fmt::{Display, Result as FmtResult, Formatter};
 use chrono::{UTC, NaiveDateTime, NaiveDate, NaiveTime};
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use serde::de::{Visitor, Error};
@@ -172,7 +173,7 @@ impl<F, M> Date<F, M>
     /// println!("{}", fmt);
     /// ```
     pub fn format(&self) -> String {
-        F::format(&self.value)
+        F::format(&self.value).to_string()
     }
 
     /// Change the format/mapping of this date.
@@ -212,6 +213,15 @@ impl<F, M> Default for Date<F, M>
     }
 }
 
+impl<F, M> Display for Date<F, M> 
+    where F: DateFormat,
+          M: DateMapping<Format = F>
+{
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", F::format(&self.value))
+    }
+}
+
 impl<F, M> Serialize for Date<F, M>
     where F: DateFormat,
           M: DateMapping<Format = F>
@@ -219,7 +229,7 @@ impl<F, M> Serialize for Date<F, M>
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        serializer.serialize_str(&self.format())
+        serializer.collect_str(&F::format(&self.value))
     }
 }
 
@@ -299,7 +309,16 @@ impl<'a, F, M> DateBrw<'a, F, M>
 
     #[doc(hidden)]
     pub fn format(&self) -> String {
-        F::format(&self.value)
+        F::format(&self.value).to_string()
+    }
+}
+
+impl<'a, F, M> Display for DateBrw<'a, F, M> 
+    where F: DateFormat,
+          M: DateMapping<Format = F>
+{
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", F::format(&self.value))
     }
 }
 
@@ -316,6 +335,6 @@ impl<'a, F, M> Serialize for DateBrw<'a, F, M>
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        serializer.serialize_str(&self.format())
+        serializer.collect_str(&F::format(&self.value))
     }
 }

--- a/types/src/date/format.rs
+++ b/types/src/date/format.rs
@@ -122,6 +122,16 @@ impl<'a> Display for FormattedDate<'a> {
     }
 }
 
+impl<'a> Into<String> for FormattedDate<'a> {
+    fn into(self) -> String {
+        match self.inner {
+            FormattedDateInner::Delayed(inner) => inner.to_string(),
+            FormattedDateInner::Buffered(inner) => inner,
+            FormattedDateInner::Number(inner) => inner.to_string()
+        }
+    }
+}
+
 impl<'a> From<DelayedFormat<IntoIter<Item<'a>>>> for FormattedDate<'a> {
     fn from(formatted: DelayedFormat<IntoIter<Item<'a>>>) -> Self {
         FormattedDate {

--- a/types/src/date/formats.rs
+++ b/types/src/date/formats.rs
@@ -59,6 +59,6 @@ impl DateFormat for EpochMillis {
 
     fn format<'a>(date: &DateTime<UTC>) -> FormattedDate<'a> {
         let msec = (date.timestamp() * 1000) + (date.nanosecond() as i64 / 1000000);
-        (msec as i64).into()
+        msec.into()
     }
 }

--- a/types/src/date/formats.rs
+++ b/types/src/date/formats.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, NaiveDateTime, UTC, Timelike};
 use std::error::Error;
-use super::{DateFormat, ParseError};
+use super::{DateFormat, FormattedDate, ParseError};
 
 /// Format for default `chrono::DateTime`.
 #[derive(ElasticDateFormat, PartialEq, Debug, Default, Clone, Copy)]
@@ -57,12 +57,8 @@ impl DateFormat for EpochMillis {
         Ok(DateTime::from_utc(NaiveDateTime::from_timestamp(s, m as u32 * 1000000), UTC))
     }
 
-    fn format(date: &DateTime<UTC>) -> String {
-        let mut fmtd = String::new();
-
-        let msec = ((date.timestamp() * 1000) + (date.nanosecond() as i64 / 1000000)).to_string();
-        fmtd.push_str(&msec);
-
-        fmtd
+    fn format<'a>(date: &DateTime<UTC>) -> FormattedDate<'a> {
+        let msec = (date.timestamp() * 1000) + (date.nanosecond() as i64 / 1000000);
+        (msec as i64).into()
     }
 }

--- a/types/src/date/mod.rs
+++ b/types/src/date/mod.rs
@@ -71,8 +71,8 @@
 //! impl DateFormat for MyCustomFormat {
 //!     fn name() -> &'static str { "yyyy-MM-dd'T'HH:mm:ssZ" }
 //!
-//!     fn format(date: &DateTime<UTC>) -> String {
-//!         date.to_rfc3339()
+//!     fn format<'a>(date: &DateTime<UTC>) -> FormattedDate<'a> {
+//!         date.to_rfc3339().into()
 //!     }
 //!
 //!     fn parse(date: &str) -> Result<DateTime<UTC>, ParseError> {

--- a/types/tests/date/formats.rs
+++ b/types/tests/date/formats.rs
@@ -258,8 +258,8 @@ fn custom_format() {
     impl DateFormat for MyCustomFormat {
         fn name() -> &'static str { "yyyy-MM-dd'T'HH:mm:ssZ" }
     
-        fn format(date: &DateTime<UTC>) -> String {
-            date.to_rfc3339()
+        fn format<'a>(date: &DateTime<UTC>) -> FormattedDate<'a> {
+            date.to_rfc3339().into()
         }
         
         fn parse(date: &str) -> Result<DateTime<UTC>, ParseError> {


### PR DESCRIPTION
Closes #60.

This adds an intermediate `FormattedDate` struct that collects a few different representations for dates. For most cases, it wraps the `chrono::DelayedFormat`, but also supports an `i64` for dates that can be represented as numbers.

Performance wise it saves a string allocation for each date. I've updated the benches to use `serde_json`, so they appear to take the same amount of time (we're using `serde_json::to_string`).