### PR TITLE
Fix build on nightly rustc

### DIFF
--- a/types/src/boolean/mapping.rs
+++ b/types/src/boolean/mapping.rs
@@ -14,8 +14,9 @@ impl<T, M> FieldType<M, BooleanFormat> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct BooleanFormat;
+pub struct BooleanFormat;
 
 /**
 The base requirements for mapping a `boolean` type.

--- a/types/src/date/mapping.rs
+++ b/types/src/date/mapping.rs
@@ -21,8 +21,9 @@ impl<T, F, M> FieldType<M, DateFormatWrapper<F>> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct DateFormatWrapper<F>
+pub struct DateFormatWrapper<F>
     where F: DateFormat
 {
     _f: PhantomData<F>,
@@ -116,7 +117,7 @@ pub trait DateMapping
 {
     /**
     The date format bound to this mapping.
-    
+
     The value of `Format::name()` is what's sent to Elasticsearch as the format to use.
     This is also used to serialise and deserialise formatted `Date`s.
     */

--- a/types/src/document/mapping.rs
+++ b/types/src/document/mapping.rs
@@ -30,8 +30,9 @@ pub const DYNAMIC_DATATYPE: &'static str = "dynamic";
 /** Elasticsearch datatype name. */
 pub const NESTED_DATATYPE: &'static str = "nested";
 
+#[doc(hidden)]
 #[derive(Default)]
-struct DocumentFormat;
+pub struct DocumentFormat;
 
 /** The base requirements for mapping an `object` type. */
 pub trait DocumentMapping
@@ -129,14 +130,14 @@ This trait is automatically implemented for you when you `#[derive(ElasticType)]
 pub trait PropertiesMapping {
     /**
     The number of mapped property fields for this type.
-    
+
     This number should be the same as the number of fields being serialised by `serialize_props`.
     */
     fn props_len() -> usize;
 
     /**
     Serialisation for the mapped property fields on this type.
-    
+
     You can use the `field_ser` function to simplify `serde` calls.
     */
     fn serialize_props<S>(state: &mut S) -> Result<(), S::Error> where S: SerializeStruct;

--- a/types/src/geo/point/mapping.rs
+++ b/types/src/geo/point/mapping.rs
@@ -22,8 +22,9 @@ impl<T, F, M> FieldType<M, GeoPointFormatWrapper<F>> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct GeoPointFormatWrapper<F>
+pub struct GeoPointFormatWrapper<F>
     where F: GeoPointFormat
 {
     _f: PhantomData<F>,
@@ -119,7 +120,7 @@ pub trait GeoPointMapping
 {
     /**
     The format used to serialise and deserialise the geo point.
-    
+
     The format isn't actually a part of the Elasticsearch mapping for a `geo_point`,
     but is included on the mapping to keep things consistent.
     */

--- a/types/src/geo/shape/mapping.rs
+++ b/types/src/geo/shape/mapping.rs
@@ -15,8 +15,9 @@ impl<T, M> FieldType<M, GeoShapeFormat> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct GeoShapeFormat;
+pub struct GeoShapeFormat;
 
 /**
 The base requirements for mapping a `geo_shape` type.
@@ -126,7 +127,7 @@ pub trait GeoShapeMapping
     /**
     Used as a hint to the `PrefixTree` about how precise it should be.
     Defaults to `0.025` (2.5%) with `0.5` as the maximum supported value.
-    
+
     > PERFORMANCE NOTE: This value will default to `0` if a `precision` or `tree_level` definition is explicitly defined.
     This guarantees spatial precision at the level defined in the mapping.
     This can lead to significant memory usage for high resolution shapes with low error

--- a/types/src/ip/mapping.rs
+++ b/types/src/ip/mapping.rs
@@ -15,8 +15,9 @@ impl<T, M> FieldType<M, IpFormat> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct IpFormat;
+pub struct IpFormat;
 
 /**
 The base requirements for mapping a `ip` type.

--- a/types/src/number/mapping.rs
+++ b/types/src/number/mapping.rs
@@ -68,8 +68,9 @@ use document::FieldType;
 
 macro_rules! number_mapping {
     ($mapping:ident, $format:ident, $field_trait:ident, $datatype_name:expr, $std_ty:ty) => (
+        #[doc(hidden)]
         #[derive(Default)]
-        struct $format;
+        pub struct $format;
 
         /** A field that will be mapped as a number. */
         pub trait $field_trait<M> where M: $mapping {}
@@ -126,8 +127,8 @@ macro_rules! number_mapping {
             fn store() -> Option<bool> { None }
         }
 
-        impl <T> FieldMapping<$format> for T 
-            where T: $mapping 
+        impl <T> FieldMapping<$format> for T
+            where T: $mapping
         {
             fn data_type() -> &'static str { $datatype_name }
         }

--- a/types/src/private/impls.rs
+++ b/types/src/private/impls.rs
@@ -35,7 +35,7 @@ In Elasticsearch, arrays and optional types aren't special, anything can be inde
 So the mapping for an array or optional type is just the mapping for the type it contains.
 */
 #[derive(Debug, Default, Clone)]
-struct WrappedMapping<M, F>
+pub struct WrappedMapping<M, F>
     where M: FieldMapping<F>,
           F: Default
 {

--- a/types/src/string/keyword/mapping.rs
+++ b/types/src/string/keyword/mapping.rs
@@ -16,8 +16,9 @@ impl<T, M> FieldType<M, KeywordFormat> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct KeywordFormat;
+pub struct KeywordFormat;
 
 /**
 The base requirements for mapping a `string` type.
@@ -119,12 +120,12 @@ pub trait KeywordMapping
     Multi-fields allow the same string value to be indexed in multiple ways for different purposes,
     such as one field for search and a multi-field for sorting and aggregations,
     or the same string value analyzed by different analyzers.
-    
+
     # Examples
-    
+
     Subfields are provided as simple `struct`s, so you don't need to define a separate type
     to map them:
-    
+
     ```
     # #[macro_use]
     # extern crate elastic_types;
@@ -136,17 +137,17 @@ pub trait KeywordMapping
     # impl KeywordMapping for MyStringMapping {
     fn fields() -> Option<BTreeMap<&'static str, StringField>> {
             let mut fields = BTreeMap::new();
-    
+
         //Add a `token_count` as a sub field
         fields.insert("count", StringField::TokenCount(
             ElasticTokenCountFieldMapping::default())
         );
-    
+
         //Add a `completion` suggester as a sub field
         fields.insert("comp", StringField::Completion(
             ElasticCompletionFieldMapping::default())
         );
-    
+
         Some(fields)
         }
     # }

--- a/types/src/string/text/mapping.rs
+++ b/types/src/string/text/mapping.rs
@@ -16,8 +16,9 @@ impl<T, M> FieldType<M, TextFormat> for T
 {
 }
 
+#[doc(hidden)]
 #[derive(Default)]
-struct TextFormat;
+pub struct TextFormat;
 
 /**
 The base requirements for mapping a `string` type.
@@ -126,12 +127,12 @@ pub trait TextMapping
     Multi-fields allow the same string value to be indexed in multiple ways for different purposes,
     such as one field for search and a multi-field for sorting and aggregations,
     or the same string value analyzed by different analyzers.
-    
+
     # Examples
-    
+
     Subfields are provided as simple `struct`s, so you don't need to define a separate type
     to map them:
-    
+
     ```
     # #[macro_use]
     # extern crate elastic_types;
@@ -143,17 +144,17 @@ pub trait TextMapping
     # impl TextMapping for MyStringMapping {
     fn fields() -> Option<BTreeMap<&'static str, StringField>> {
         let mut fields = BTreeMap::new();
-    
+
         //Add a `token_count` as a sub field
         fields.insert("count", StringField::TokenCount(
             ElasticTokenCountFieldMapping::default())
         );
-    
+
         //Add a `completion` suggester as a sub field
         fields.insert("comp", StringField::Completion(
             ElasticCompletionFieldMapping::default())
         );
-    
+
         Some(fields)
     }
     # }


### PR DESCRIPTION
Hi.
https://github.com/rust-lang/rust/pull/42125 is going to fix some holes in `rustc`'s privacy checker.
Unfortunately, it can break code sometimes.
`crates.io` testing found 3 unexpected regressions, including this crate.
This PR updates the code to build successfully with https://github.com/rust-lang/rust/pull/42125.

In theory leaking a private type from its module should be prevented by private-in-public errors, but it didn't happened here and this crate seems to use a lot of "it's an implementation detail, but we leak it" types. The fix in this PR works, but if `#[doc(hidden)]` is not desired, then the solution is to still mark the leaked structures as `pub`, but make them "unnameable" by declaring them in private modules, like the example in https://github.com/rust-lang/rust/issues/34537 shows.