### PR TITLE
Re-export all items in derive module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
     - rust: nightly
       env:
         - CRATE="types"
+    - rust: nightly
+      env:
+        - CRATE="tests/derive-compile-test"
 env:
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "types",
     "types-derive",
     "types-derive-internals",
+    "tests/derive-compile-test"
 ]

--- a/tests/derive-compile-test/.gitignore
+++ b/tests/derive-compile-test/.gitignore
@@ -1,0 +1,4 @@
+*.bk
+
+/target/
+/obj/

--- a/tests/derive-compile-test/Cargo.toml
+++ b/tests/derive-compile-test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "derive-compile-test"
+version = "0.1.0"
+authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+
+[dependencies]
+elastic_types = { version = "*", path = "../../types" }
+elastic_types_derive = { version = "*", path = "../../types-derive" }

--- a/tests/derive-compile-test/src/main.rs
+++ b/tests/derive-compile-test/src/main.rs
@@ -1,0 +1,19 @@
+/*!
+Test crate to ensure derive macros can be used in a fresh crate without any extra dependencies.
+*/
+
+extern crate elastic_types;
+#[macro_use]
+extern crate elastic_types_derive;
+
+#[derive(ElasticDateFormat, PartialEq, Debug, Default, Clone, Copy)]
+#[elastic(date_format="yyyy-MM-dd'T'HH:mm:ssZ")]
+pub struct DerivedDateFormat;
+
+#[derive(ElasticType)]
+pub struct DerivedDocument {
+    pub field1: String,
+    pub field2: i32,
+}
+
+fn main() { }

--- a/types-derive-internals/Cargo.toml
+++ b/types-derive-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types_derive_internals"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Codegen internals for elastic_types."

--- a/types-derive-internals/src/date_format/mod.rs
+++ b/types-derive-internals/src/date_format/mod.rs
@@ -34,7 +34,7 @@ pub fn expand_derive(crate_root: Tokens,
     let tokens: Vec<Tokens> = parse::to_tokens(format)
         ?
         .into_iter()
-        .map(|t| t.into())
+        .map(|t| t.into_tokens(&crate_root))
         .collect();
 
     let derived = impl_date_format(crate_root, input, name, &tokens);
@@ -97,24 +97,24 @@ fn get_name_from_attr<'a>(item: &'a syn::MacroInput) -> Option<&'a str> {
     val.and_then(|v| get_str_from_lit(v).ok())
 }
 
-impl<'a> Into<Tokens> for parse::DateFormatToken<'a> {
-    fn into(self) -> Tokens {
+impl<'a> parse::DateFormatToken<'a> {
+    fn into_tokens(self, crate_root: &Tokens) -> Tokens {
         use self::parse::DateFormatToken::*;
 
         match self {
-            Year => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Year, ::chrono::format::Pad::Zero)),
-            Month => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Month, ::chrono::format::Pad::Zero)),
-            DayOfMonth => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Day, ::chrono::format::Pad::Zero)),
-            DayOfYear => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Ordinal, ::chrono::format::Pad::Zero)),
-            Hour => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Hour, ::chrono::format::Pad::Zero)),
-            Minute => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Minute, ::chrono::format::Pad::Zero)),
-            Second => quote!(::chrono::format::Item::Numeric(::chrono::format::Numeric::Second, ::chrono::format::Pad::Zero)),
+            Year => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Year, #crate_root::derive::Pad::Zero)),
+            Month => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Month, #crate_root::derive::Pad::Zero)),
+            DayOfMonth => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Day, #crate_root::derive::Pad::Zero)),
+            DayOfYear => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Ordinal, #crate_root::derive::Pad::Zero)),
+            Hour => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Hour, #crate_root::derive::Pad::Zero)),
+            Minute => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Minute, #crate_root::derive::Pad::Zero)),
+            Second => quote!(#crate_root::derive::Item::Numeric(#crate_root::derive::Numeric::Second, #crate_root::derive::Pad::Zero)),
             Millisecond => {
-                quote!(::chrono::format::Item::Fixed(::chrono::format::Fixed::Nanosecond3))
+                quote!(#crate_root::derive::Item::Fixed(#crate_root::derive::Fixed::Nanosecond3))
             }
-            Utc => quote!(::chrono::format::Item::Literal("Z")),
-            Delim(s) => quote!(::chrono::format::Item::Literal(#s)),
-            Escaped(s) => quote!(::chrono::format::Item::Literal(#s)),
+            Utc => quote!(#crate_root::derive::Item::Literal("Z")),
+            Delim(s) => quote!(#crate_root::derive::Item::Literal(#s)),
+            Escaped(s) => quote!(#crate_root::derive::Item::Literal(#s)),
         }
     }
 }

--- a/types-derive-internals/src/elastic_type/mod.rs
+++ b/types-derive-internals/src/elastic_type/mod.rs
@@ -115,7 +115,7 @@ fn impl_props_mapping(crate_root: Tokens,
             fn props_len() -> usize { #stmts_len }
 
             fn serialize_props<S>(state: &mut S) -> ::std::result::Result<(), S::Error> 
-                where S: ::serde::ser::SerializeStruct {
+                where S: #crate_root::derive::SerializeStruct {
                 #(#stmts)*
                 Ok(())
             }

--- a/types-derive/Cargo.toml
+++ b/types-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types_derive"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Compile-time code generation for Elasticsearch type implementations."
@@ -11,6 +11,6 @@ name = "elastic_types_derive"
 proc-macro = true
 
 [dependencies]
-elastic_types_derive_internals = "~0.19.0"
+elastic_types_derive_internals = { version = "~0.19.1", path = "../types-derive-internals" }
 syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
 quote = "~0.3.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "A strongly-typed implementation of Elasticsearch core types and Mapping API."
@@ -15,7 +15,7 @@ geo = "~0.4.0"
 geohash = "~0.4.0"
 geojson = "~0.8.0"
 serde_derive = "~1"
-elastic_types_derive = "~0.19.0"
+elastic_types_derive = { version = "~0.19.1", path = "../types-derive" }
 
 [dev-dependencies]
 json_str = "^0.*"

--- a/types/src/derive.rs
+++ b/types/src/derive.rs
@@ -1,13 +1,16 @@
 /*! Functions that are exported and used by `elastic_types_derive`. */
 
 use chrono::{DateTime, Utc};
-use chrono::format::{self, Item, Parsed};
+use chrono::format::{self, Parsed};
 
 use private::field::FieldMapping;
 
 pub use date::{DateFormat, DateValue, ParseError, FormattedDate};
 pub use document::{DocumentType, FieldType, field_ser};
 pub use document::mapping::{DocumentMapping, PropertiesMapping};
+
+pub use chrono::format::{Item, Pad, Numeric, Fixed};
+pub use serde::ser::SerializeStruct;
 
 /** Get the mapping for a field. */
 #[inline]


### PR DESCRIPTION
Fixes #84 

Ensures that the needed bits for deriving date formats and document types are re-exported in the `derive` module, so users don't need dependencies on those crates.

I've also added a simple compile test that can also be used down the track to ensure `elastic_types` imported with a different name can still be derived.